### PR TITLE
Fix #2: Lägg till endpoint för att markera en todo som klar/oklar

### DIFF
--- a/src/main/java/se/moise/todoservice/controller/TodoController.java
+++ b/src/main/java/se/moise/todoservice/controller/TodoController.java
@@ -71,6 +71,16 @@ public class TodoController {
     }
 
     // ---------------------------------------------------
+    // PATCH (Toggle done/undone på en todo)
+    // ---------------------------------------------------
+    @PatchMapping("/{id}/toggle")
+    public ResponseEntity<Todo> toggle(@PathVariable Long id) {
+        return service.toggle(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    // ---------------------------------------------------
     // DELETE (en todo)
     // ---------------------------------------------------
     @DeleteMapping("/{id}")

--- a/src/main/java/se/moise/todoservice/service/TodoService.java
+++ b/src/main/java/se/moise/todoservice/service/TodoService.java
@@ -45,6 +45,17 @@ public class TodoService {
     }
 
     // ---------------------------------------------------
+    // TOGGLE DONE
+    // ---------------------------------------------------
+    @Transactional
+    public Optional<Todo> toggle(Long id) {
+        return repo.findById(id).map(todo -> {
+            todo.setDone(!todo.isDone());  // Växla mellan true/false
+            return repo.save(todo);
+        });
+    }
+
+    // ---------------------------------------------------
     // DELETE (en)
     // ---------------------------------------------------
     @Transactional


### PR DESCRIPTION
Denna PR implementerar en PATCH-endpoint för att markera en todo som klar/oklar.

- Ny endpoint: PATCH /api/todos/{id}/toggle
- Toggle logik i TodoService (växlar fältet 'done' mellan true/false)
- Fältet 'done' finns redan i Todo-modellen
- Returnerar 200 OK med uppdaterad todo om den finns, annars 404 Not Found

Closes #2
